### PR TITLE
[FIX] fixing valgrind errors from tests

### DIFF
--- a/tests/tests_accept_clients.c
+++ b/tests/tests_accept_clients.c
@@ -35,9 +35,9 @@ Test(accept_new_clients_no_new_client, tests_select_accept1)
         cr_assert_fail("Error to create socket file descriptor");
     }
     if (FAILURE == bind(socket_controller.fd, (struct sockaddr *)&socket_controller.address, socket_controller.sockaddr_length))
-        cr_assert_fail("Error with bind");
-    if (FAILURE == listen(socket_controller.fd, 128))
-        cr_assert_fail("Error with listen");
+        cr_log_error("Error when calling bind function");
+    if (FAILURE == listen(socket_controller.fd, BACKLOG))
+        cr_log_error("Error when calling listen function");
 
     return_from_function = INIT_INT;
     return_from_function = accept_new_clients(&socket_controller, &clients);
@@ -45,9 +45,8 @@ Test(accept_new_clients_no_new_client, tests_select_accept1)
     cr_assert(NO_NEW_CLIENT_SIZE == clients.size);
     return_from_function = INIT_INT;
     return_from_function = close(socket_controller.fd);
-    if (SOCKET_ERROR == return_from_function) {
-        cr_assert_fail("Error when closing the data socket fd");
-    }
+    if (SOCKET_ERROR == return_from_function)
+        cr_log_error("Error when calling close function");
     cr_assert(SUCCESS == return_from_function);
 }
 

--- a/tests/tests_data_read_write.c
+++ b/tests/tests_data_read_write.c
@@ -19,6 +19,7 @@
 #define VALID_VALUE     0
 #define STDOUT          1
 #define TESTING_STRING  "testing\n"
+#define TESTING_SIZE    10
 
 Test(read_data_from_failure, invalid_file_descriptor)
 {
@@ -26,6 +27,7 @@ Test(read_data_from_failure, invalid_file_descriptor)
     struct socket_data_s data;
 
     data.fd = INVALID_VALUE;
+    data.size = TESTING_SIZE;
     return_from_function = read_data_from(&data, SINGLE_ELEMENT);
     cr_assert(FAILURE == return_from_function);
 }
@@ -36,6 +38,7 @@ Test(write_data_to_failure, invalid_file_descriptor)
     struct socket_data_s data;
 
     data.fd = INVALID_VALUE;
+    data.size = TESTING_SIZE;
     return_from_function = write_data_to(&data, SINGLE_ELEMENT);
     cr_assert(FAILURE == return_from_function);
 }
@@ -47,8 +50,11 @@ Test(write_data_to_success, message_stdout)
 
     data.fd = STDOUT;
     data.size = strlen(TESTING_STRING);
-    data.data = malloc(data.size);
+    data.data = strdup(TESTING_STRING);
+    if (NULL == data.data)
+        cr_log_error("Error when calling strdup function");
     return_from_function = write_data_to(&data, SINGLE_ELEMENT);
+    free(data.data);
     cr_assert(SUCCESS == return_from_function);
     cr_assert(VALID_VALUE == data.size);
 }


### PR DESCRIPTION
There were uninitialized variables in the structures that I used in the unit tests. They were causing conditional jumps depending on uninitialized value.
I fixed that.